### PR TITLE
fix: caption on architecture diagram

### DIFF
--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -23,19 +23,21 @@ The user's application layer interacts with Strata in three ways:
 <figure markdown="span">
   ![Architecture Diagram](../images/architecture_diagram.jpg){ loading=lazy }
   <figcaption>
-      This diagram illustrates the overall system architecture and
-      the data flow between different components of Strata
-      and the entities interacting with the system.
-      There are three layers: bitcoin layer at the base, Strata layer above it,
-      and the user application layer that sits on top of the Strata layer.
-      The direction of arrows indicate the direction of
-      data flow between the components,
-      and the text in the arrows indicate the data.
-      The centralized services are the services that are run by Alpen Labs.
-      Other components within Strata layer (the bundler and the full node)
-      can be run by anyone in our devnet community.
-   </figcaption>
+    Architecture diagram.
+  </figcaption>
 </figure>
+
+The diagram above illustrates the overall system architecture and
+the data flow between different components of Strata
+and the entities interacting with the system.
+There are three layers: bitcoin layer at the base, Strata layer above it,
+and the user application layer that sits on top of the Strata layer.
+The direction of arrows indicate the direction of
+data flow between the components,
+and the text in the arrows indicate the data.
+The centralized services are the services that are run by Alpen Labs.
+Other components within Strata layer (the bundler and the full node)
+can be run by anyone in our devnet community.
 
 ## User application layer
 


### PR DESCRIPTION
## Description

Fix the long caption in the architecture diagram.

---

## Type of Change

- [ ] New Document
- [ ] Update to Existing Document
- [x] Bug Fix
- [ ] Question/clarification
- [ ] Other (please describe):

---

## Related Issues

Link any related issues or pull requests here.
Use the format `Fixes #issue-number` to automatically close the related issue
when this pull request is merged.

---

## Checklist

- [ ] I have reviewed the existing documentation to avoid duplication.
- [ ] The new or updated document includes clear and concise information.
- [ ] All relevant sections (e.g., introduction, usage examples, references)
      are included.
- [ ] The document follows the project's style guide and formatting rules.
- [ ] I have included any necessary references or external resources.
- [ ] Spellcheck and grammar check have been performed.
- [ ] (For updates) I have verified that the changes reflect the current state
      of the project.

---

## Reviewer Checklist

- [ ] The purpose and scope of the document are clear.
- [ ] The document is easy to understand and follow.
- [ ] There are no typos or grammatical errors.
- [ ] All necessary sections are included and well-structured.
- [ ] The document is consistent with the project's style guide.
- [ ] Any referenced links or resources are valid and appropriate.

---

**Thank you for contributing to our documentation!**
