### PR TITLE
fix(bridge): important details on DRT

### DIFF
--- a/docs/technical/bitcoin-bridge.md
+++ b/docs/technical/bitcoin-bridge.md
@@ -70,6 +70,9 @@ who sends 10[^fees] BTC to a P2TR address, where:
 1. The script path spend has two paths:
    1. "Deposit path", an $N$-of-$N$ multisig path,
       where $N$ is the number of operators in the bridge.
+      Note that this uses Schnorr key aggregation,
+      hence the signature is aggregated into a single signature that
+      validates all $N$ operators' signatures.
    1. "Take back" path,
       which allows the user to take back their funds if the bridge fails to
       move funds from the Deposit Request Transaction (DRT)
@@ -77,7 +80,10 @@ who sends 10[^fees] BTC to a P2TR address, where:
       i.e. it is time-locked and the user can spend it by providing a signature.
 
 This transaction has some metadata attached to it, in the form of an `OP_RETURN`
-output, that can be up to 80 bytes long (according to bitcoin standardness policy),
+output, that must be the **second** output of the transaction in order for the
+sequencer to be able to detect the transaction.
+The `OP_RETURN` output can be up to 80 bytes long
+(according to bitcoin standardness policy),
 and is composed of the following data:
 
 1. Magic bytes.

--- a/justfile
+++ b/justfile
@@ -31,6 +31,7 @@ spell-check:
 spell-add *WORDS:
     @echo "Adding {{ WORDS }} to the dictionary"
     for word in {{ WORDS }}; do echo $word >> project-words.txt; done
+    @just spell-sort
 
 # Sort the dictionary
 spell-sort:

--- a/project-words.txt
+++ b/project-words.txt
@@ -1,6 +1,7 @@
 NUMS
 PUSHBYTES
 Rollkit
+Schnorr
 Taproot
 Tapscript
 Taptree


### PR DESCRIPTION
## Description

While testing the Bridge Client, I've realized that we're missing some important details on the Deposit Request Transaction (DRT) about:

1. that the multisig N-of-N is a Schnorr aggregated sig
1. that the `OP_RETURN` needs to be the first output

---

## Type of Change

- [ ] New Document
- [x] Update to Existing Document
- [ ] Bug Fix
- [ ] Question/clarification
- [ ] Other (please describe):

---

## Checklist

- [ ] I have reviewed the existing documentation to avoid duplication.
- [ ] The new or updated document includes clear and concise information.
- [ ] All relevant sections (e.g., introduction, usage examples, references)
      are included.
- [ ] The document follows the project's style guide and formatting rules.
- [ ] I have included any necessary references or external resources.
- [ ] Spellcheck and grammar check have been performed.
- [ ] (For updates) I have verified that the changes reflect the current state
      of the project.

---

## Reviewer Checklist

- [ ] The purpose and scope of the document are clear.
- [ ] The document is easy to understand and follow.
- [ ] There are no typos or grammatical errors.
- [ ] All necessary sections are included and well-structured.
- [ ] The document is consistent with the project's style guide.
- [ ] Any referenced links or resources are valid and appropriate.

---

**Thank you for contributing to our documentation!**
